### PR TITLE
De-select LocalBusiness

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,7 @@
 						<div class="form-group">
 							<label for="place-type" class="input-label required">Place Type</label>
 							<select name="@type" class="input" id="place-type" required="">
+								<option value="">Select Type of Business/Place</option>
 								<optgroup label="Food Service">
 									<option value="Restaurant">Restaurant</option>
 									<option value="FastFoodRestaurant">Fast Food</option>

--- a/index.html
+++ b/index.html
@@ -362,7 +362,7 @@
 									<option value="SelfStorage">Self Storage Facility</option>
 									<option value="Church">Church</option>
 									<option value="CivicStructure">Civic Structure</option>
-									<option value="LocalBusiness" selected="">Other Business</option>
+									<option value="LocalBusiness">Other Business</option>
 								</optgroup>
 							</select>
 						</div>


### PR DESCRIPTION
Having none selected by default should make it more obvious that one needs to be selected, and it will make it a bit easier since it would require scrolling down instead of up.